### PR TITLE
Fix attribute error in python market hours example

### DIFF
--- a/content/api-documentation/how-to/market-hours/examples/marketHours.py
+++ b/content/api-documentation/how-to/market-hours/examples/marketHours.py
@@ -8,7 +8,7 @@ print('The market is {}'.format('open.' if clock.is_open else 'closed.'))
 
 # Check when the market was open on Dec. 1, 2018
 date = '2018-12-01'
-calendar = api.get_calendar(start=date, end=date)
+calendar = api.get_calendar(start=date, end=date)[0]
 print('The market opened at {} and closed at {} on {}.'.format(
     calendar.open,
     calendar.close,


### PR DESCRIPTION
Because the call to `api.get_calendar()` returns an array of calendars for the time frame specified, the example needs to index into the array for the print to function properly. As it stands, Python returns an attribute error, as an array containing calendars has no attributes `open` or `close`.