### PR TITLE
Fix equality check in python order list example

### DIFF
--- a/content/api-documentation/how-to/orders/examples/getOrders.py
+++ b/content/api-documentation/how-to/orders/examples/getOrders.py
@@ -9,6 +9,6 @@ closed_orders = api.list_orders(
 )
 
 # Get only the closed orders for a particular stock
-closed_aapl_orders = [o for o in closed_orders if o.symbol is 'AAPL']
+closed_aapl_orders = [o for o in closed_orders if o.symbol == 'AAPL']
 print(closed_aapl_orders)
 


### PR DESCRIPTION
Using `is` checks identity, which isn't what you want here. Copy/pasting the example into a python terminal yields an empty list. Substituting with `==` for an equality check achieves the desired result.