### PR TITLE
Remove exchange field from order entity

### DIFF
--- a/data/webapi/entities/order.yaml
+++ b/data/webapi/entities/order.yaml
@@ -23,9 +23,6 @@ spec:
   - name: symbol
     type: string
     desc: Asset symbol
-  - name: exchange
-    type: string
-    desc: Asset exchange
   - name: asset_class
     type: string
     desc: Asset class
@@ -68,7 +65,6 @@ example: |
     "failed_at": "2018-10-05T05:48:59Z",
     "asset_id": "904837e3-3b76-47ec-b432-046db621571b",
     "symbol": "AAPL",
-    "exchange": "NASDAQ",
     "asset_class": "us_equity",
     "qty": "15",
     "filled_qty": "0",


### PR DESCRIPTION
An order object as returned by the any of the /v1/orders endpoints does
not contain an exchange field. Here is such an object retrieved using
the alpaca-trade-api-python package:

  [Order({   'asset_class': 'us_equity',
    'asset_id': 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415',
    'canceled_at': None,
    'client_order_id': '358571d3-9092-41b0-9f83-c9e653ebc4d2',
    'created_at': '2019-04-24T02:13:02.25048Z',
    'expired_at': None,
    'failed_at': None,
    'filled_at': None,
    'filled_avg_price': None,
    'filled_qty': '0',
    'id': '5674211d-7a38-4dd2-ad32-10fad195daab',
    'limit_price': '10000',
    'order_type': 'limit',
    'qty': '1',
    'side': 'buy',
    'status': 'new',
    'stop_price': None,
    'submitted_at': '2019-04-24T02:13:02.245256Z',
    'symbol': 'AAPL',
    'time_in_force': 'day',
    'type': 'limit',
    'updated_at': '2019-04-24T02:13:02.25579Z'})]

Hence, remove the field from the order entity documentation.