### PR TITLE
Document Position.unrealized_pl as being a number

### DIFF
--- a/data/webapi/entities/position.yaml
+++ b/data/webapi/entities/position.yaml
@@ -27,7 +27,7 @@ spec:
     type: string<number>
     desc: Total cost basis in dollar
   - name: unrealized_pl
-    type: string<string>
+    type: string<number>
     desc: Unrealized profit/loss in dollar
   - name: unrealized_plpc
     type: string<number>


### PR DESCRIPTION
The Position.unrealized_pl member is documented as having type
string<string>. That doesn't really make sense, I guess, but it also is
not in line with how other, similar members are documented:
string<number>.
With this change we adjust the documentation accordingly.