### PR TITLE
Change single quotes to double quotes for Account Activity JSON example entities

### DIFF
--- a/data/webapi/entities/account-nontrade-activity-v2.yaml
+++ b/data/webapi/entities/account-nontrade-activity-v2.yaml
@@ -22,11 +22,11 @@ spec:
     desc: For dividend activities, the average amount paid per share. Not present for other activity types.
 example: |
   {
-    'activity_type': 'DIV',
-    'id': '20190801011955195::5f596936-6f23-4cef-bdf1-3806aae57dbf',
-    'date': '2019-08-01',
-    'net_amount': '1.02',
-    'symbol': 'T'
-    'qty': '2',
-    'per_share_amount': '0.51'
+    "activity_type": "DIV",
+    "id": "20190801011955195::5f596936-6f23-4cef-bdf1-3806aae57dbf",
+    "date": "2019-08-01",
+    "net_amount": "1.02",
+    "symbol": "T"
+    "qty": "2",
+    "per_share_amount": "0.51"
   }

--- a/data/webapi/entities/account-trade-activity-v2.yaml
+++ b/data/webapi/entities/account-trade-activity-v2.yaml
@@ -34,14 +34,14 @@ spec:
       `fill` or `partial_fill`
 example: |
   {
-    'activity_type': 'FILL',
-    'cum_qty': '1',
-    'id': '20190524113406977::8efc7b9a-8b2b-4000-9955-d36e7db0df74',
-    'leaves_qty': '0',
-    'price': '1.63',
-    'qty': '1',
-    'side': 'buy',
-    'symbol': 'LPCN',
-    'transaction_time': '2019-05-24T15:34:06.977Z',
-    'type': 'fill'
+    "activity_type": "FILL",
+    "cum_qty": "1",
+    "id": "20190524113406977::8efc7b9a-8b2b-4000-9955-d36e7db0df74",
+    "leaves_qty": "0",
+    "price": "1.63",
+    "qty": "1",
+    "side": "buy",
+    "symbol": "LPCN",
+    "transaction_time": "2019-05-24T15:34:06.977Z",
+    "type": "fill"
   }


### PR DESCRIPTION
Change `'` to `"` in `data/webapi/entities/account-trade-activity-v2.yaml` and `data/webapi/entities/account-nontrade-activity-v2.yaml`