### PR TITLE
Fix all C# compilation errors in examples

### DIFF
--- a/content/api-documentation/how-to/account/examples/gainloss.csharp
+++ b/content/api-documentation/how-to/account/examples/gainloss.csharp
@@ -15,7 +15,6 @@ namespace GetPnLExample
 
         private static string API_SECRET = "your_secret_key";
 
-        private static AlpacaTradingClient client;
         public static async Task Main(string[] args)
         {
             // First, open the API connection
@@ -25,8 +24,9 @@ namespace GetPnLExample
             // Get account info
             var account = await client.GetAccountAsync();
 
-            # Check our current balance vs. our balance at the last market close
+            // Check our current balance vs. our balance at the last market close
             var balance_change = account.Equity - account.LastEquity;
+
             Console.WriteLine($"Today's portfolio balance change: ${balance_change}");
         }
     }

--- a/content/api-documentation/how-to/account/examples/streaming.csharp
+++ b/content/api-documentation/how-to/account/examples/streaming.csharp
@@ -14,15 +14,17 @@ namespace CodeExamples
         public static async Task Main(string[] args)
         {
             // Prepare the websocket connection and subscribe to account_updates.
-            var alpacaStreamingClient = Environments.Paper.GetAlpacaStreamingClient(API_KEY, API_SECRET);
-            alpacaStreamingClient.ConnectAndAuthenticateAsync().Wait();
+            var alpacaStreamingClient = Environments.Paper
+                .GetAlpacaStreamingClient(API_KEY, API_SECRET);
+
+            await alpacaStreamingClient.ConnectAndAuthenticateAsync();
             alpacaStreamingClient.OnAccountUpdate += HandleAccountUpdate;
 
             Console.Read();
         }
 
         // Handle incoming account updates.
-        private void HandleAccountUpdate(IAccountUpdate update)
+        private static void HandleAccountUpdate(IAccountUpdate update)
         {
             Console.WriteLine("New account status: " + update.Status.ToString());
         }

--- a/content/api-documentation/how-to/assets/examples/listAssets.csharp
+++ b/content/api-documentation/how-to/assets/examples/listAssets.csharp
@@ -1,5 +1,6 @@
 using Alpaca.Markets;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace CodeExamples

--- a/content/api-documentation/how-to/market-data/examples/getPrices.csharp
+++ b/content/api-documentation/how-to/market-data/examples/getPrices.csharp
@@ -15,14 +15,15 @@ namespace CodeExamples
         {
             // First, open the API connection
             var client = Alpaca.Markets.Environments.Paper
-                .GetAlpacaTradingClient(API_KEY, new SecretKey(API_SECRET));
+                .GetAlpacaDataClient(API_KEY, new SecretKey(API_SECRET));
 
             // Get daily price data for AAPL over the last 5 trading days.
-            var bars = await client.GetBarsetAsync(new[] { "AAPL" }, TimeFrame.Day, 5);
+            var bars = await client.GetBarSetAsync(new[] { "AAPL" }, TimeFrame.Day, 5);
 
             // See how much AAPL moved in that timeframe.
-            var startPrice = bars.First().Open;
-            var endPrice = bars.Last().Close;
+            var startPrice = bars["AAPL"].First().Open;
+            var endPrice = bars["AAPL"].Last().Close;
+
             var percentChange = (endPrice - startPrice) / startPrice * 100;
             Console.WriteLine($"AAPL moved {percentChange} over the last 5 days.");
 

--- a/content/api-documentation/how-to/market-hours/examples/marketHours.csharp
+++ b/content/api-documentation/how-to/market-hours/examples/marketHours.csharp
@@ -30,7 +30,7 @@ namespace CodeExamples
 
             // Check when the market was open on Dec. 1, 2018
             var date = new DateTime(2018, 12, 1);
-            var calendars = (await client.ListCalendarAsync(date, date)).ToList();
+            var calendars = await client.ListCalendarAsync(date, date);
             var calendarDay = calendars.First();
             Console.WriteLine($"The market opened at {calendarDay.TradingOpenTime} and closed at {calendarDay.TradingCloseTime} on {date}.");
 

--- a/content/api-documentation/how-to/orders/examples/getOrders.csharp
+++ b/content/api-documentation/how-to/orders/examples/getOrders.csharp
@@ -21,7 +21,7 @@ namespace CodeExamples
             var closedOrders = await client.ListOrdersAsync(OrderStatusFilter.Closed, limitOrderNumber: 100);
 
             // Get only the closed orders for a particular stock
-            var aaplOrders = closedOrders.Where(order => order.Symbol.equals("AAPL"));
+            var aaplOrders = closedOrders.Where(order => order.Symbol.Equals("AAPL"));
 
             Console.Read();
         }

--- a/content/api-documentation/how-to/orders/examples/placeOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/placeOrder.csharp
@@ -22,7 +22,7 @@ namespace CodeExamples
 
             // Submit a limit order to attempt to sell 1 share of AMD at a
             // particular price ($20.50) when the market opens
-            order = await client.PostOrderAsync("AMD", 1, OrderSide.Sell, OrderType.Limit, TimeInForce.Opg, 20.50);
+            order = await client.PostOrderAsync("AMD", 1, OrderSide.Sell, OrderType.Limit, TimeInForce.Opg, 20.50M);
 
             Console.Read();
         }

--- a/content/api-documentation/how-to/orders/examples/shortOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/shortOrder.csharp
@@ -18,32 +18,34 @@ namespace ShortingExample
         // The security we'll be shorting
         private static string symbol = "TSLA";
 
-        private static AlpacaTradingClient client;
         public static async Task Main(string[] args)
         {
             // First, open the API connection
-            client = Alpaca.Markets.Environments.Paper
+            var tradingClient = Alpaca.Markets.Environments.Paper
                 .GetAlpacaTradingClient(API_KEY, new SecretKey(API_SECRET));
 
+            var dataClient = Alpaca.Markets.Environments.Paper
+                .GetAlpacaDataClient(API_KEY, new SecretKey(API_SECRET));
+
             // Submit a market order to open a short position of one share
-            var order = await client.PostOrderAsync(symbol, 1, OrderSide.Sell, OrderType.Market, TimeInForce.Day);
+            var order = await tradingClient.PostOrderAsync(symbol, 1, OrderSide.Sell, OrderType.Market, TimeInForce.Day);
             Console.WriteLine("Market order submitted.");
 
             // Submit a limit order to attempt to grow our short position
             // First, get an up-to-date price for our security
-            var barSet = await client.GetBarSetAsync(new[] { symbol }, TimeFrame.Minute, 1);
+            var barSet = await dataClient.GetBarSetAsync(new[] { symbol }, TimeFrame.Minute, 1);
             var bars = barSet[symbol].ToList();
             var price = bars[0].Close;
 
             // Submit another order for one share at that price
-            order = await client.PostOrderAsync(symbol, 1, OrderSide.Sell, OrderType.Limit, TimeInForce.Day, price);
+            order = await tradingClient.PostOrderAsync(symbol, 1, OrderSide.Sell, OrderType.Limit, TimeInForce.Day, price);
             Console.WriteLine($"Limit order submitted. Limit price = {order.LimitPrice}");
 
             // Wait a few seconds for our orders to fill...
             Thread.Sleep(2000);
 
             // Check on our position
-            var position = await client.GetPositionAsync(symbol);
+            var position = await tradingClient.GetPositionAsync(symbol);
             if (position.Quantity < 0)
             {
                 Console.WriteLine($"Short position open for {symbol}");

--- a/content/api-documentation/how-to/orders/examples/streaming.csharp
+++ b/content/api-documentation/how-to/orders/examples/streaming.csharp
@@ -14,17 +14,19 @@ namespace CodeExamples
         public static async Task Main(string[] args)
         {
             // Prepare the websocket connection and subscribe to trade_updates.
-            var alpacaStreamingClient = Environments.Paper.GetAlpacaStreamingClient(API_KEY, API_SECRET);
-            alpacaStreamingClient.ConnectAndAuthenticateAsync().Wait();
+            var alpacaStreamingClient = Environments.Paper
+                .GetAlpacaStreamingClient(API_KEY, API_SECRET);
+
+            await alpacaStreamingClient.ConnectAndAuthenticateAsync();
             alpacaStreamingClient.OnTradeUpdate += HandleTradeUpdate;
 
             Console.Read();
         }
 
         // Handle incoming trade updates.
-        private void HandleTradeUpdate(ITradeUpdate update)
+        private static void HandleTradeUpdate(ITradeUpdate update)
         {
-            if update.Order.ClientOrderId.Equals("my_client_order_id")
+            if (update.Order.ClientOrderId.Equals("my_client_order_id"))
             {
                 Console.WriteLine($"Update for {update.Order.ClientOrderId}. Event: {update.Event}");
             }


### PR DESCRIPTION
There are a lot of compilation errors in C# examples in this documentation. I've created a simple script for compiling each C# example in this repo and catch at least syntax errors. This PR contains fixes for all problem code snippets.