### PR TITLE
Add Elixir Client SDK

### DIFF
--- a/content/api-documentation/client-sdk/_index.md
+++ b/content/api-documentation/client-sdk/_index.md
@@ -22,3 +22,4 @@ In addition to the SDKs directly supported by Alpaca, individual members of our 
 - R: [alpaca-for-r](https://github.com/jagg19/AlpacaforR)
 - Scala: [Alpaca Scala](https://github.com/cynance/alpaca-scala)
 - Ruby: [alpaca-trade-api](https://github.com/ccjr/alpaca-trade-api)
+- Elixir: [alpaca_elixir](https://github.com/jrusso1020/alpaca_elixir)


### PR DESCRIPTION
Add the community created Elixir Client SDK to the official docs
for easy visible and access.