### PR TITLE
Fix Alpaca Forum link in drawer

### DIFF
--- a/layouts/partials/drawer.html
+++ b/layouts/partials/drawer.html
@@ -29,7 +29,7 @@
         <ul>
           {{ partial "nav" . }}
           <li><a href="https://alpaca.markets/learn/" target="_blank" class="current">Alpaca Resources💡</a></li>
-          <li><a href="https://alpaca.markets/learn/" target="_blank" class="current">Alpaca Forum🙌</a></li>          
+          <li><a href="https://forum.alpaca.markets/" target="_blank" class="current">Alpaca Forum🙌</a></li>          
         </ul>
         {{ end }}
 


### PR DESCRIPTION
The Forum link currently leads to the Resources page.