### PR TITLE
Update _index.md - change ts link name

### DIFF
--- a/content/api-documentation/client-sdk/_index.md
+++ b/content/api-documentation/client-sdk/_index.md
@@ -19,7 +19,7 @@ In addition to the SDKs directly supported by Alpaca, individual members of our 
 
 - C++: [alpaca-trade-api-cpp](https://github.com/marpaia/alpaca-trade-api-cpp)
 - Java: [alpaca-java](https://github.com/mainstringargs/alpaca-java)
-- Node.js (TypeScript): [alpaca](https://github.com/117/alpaca)
+- Node.js (TypeScript): [alpaca-ts](https://github.com/117/alpaca)
 - R: [alpaca-for-r](https://github.com/jagg19/AlpacaforR)
 - Rust: [apca](https://github.com/d-e-s-o/apca) (SDK) & [apcacli](https://github.com/d-e-s-o/apcacli) (CLI)
 - Scala: [Alpaca Scala](https://github.com/cynance/alpaca-scala)


### PR DESCRIPTION
A better descriptive name for the typescript sdk would be alpaca-ts