### PR TITLE
Replace outdated property name with recommended one in .NET SDK example.

### DIFF
--- a/content/api-documentation/how-to/market-hours/examples/marketHours.csharp
+++ b/content/api-documentation/how-to/market-hours/examples/marketHours.csharp
@@ -33,7 +33,7 @@ namespace CodeExamples
             var calendars = await client.ListCalendarAsync(
                 new CalendarRequest().SetInclusiveTimeInterval(date, date));
             var calendarDay = calendars.First();
-            Console.WriteLine($"The market opened at {calendarDay.TradingOpenTime} and closed at {calendarDay.TradingCloseTime} on {date}.");
+            Console.WriteLine($"The market opened at {calendarDay.TradingOpenTimeUtc} and closed at {calendarDay.TradingCloseTimeUtc} on {date}.");
 
             Console.Read();
         }


### PR DESCRIPTION
After version 3.8.0 final release we have to update some C# examples to prevent compiler warnings.