### PR TITLE
Add missing comma to order yaml

### DIFF
--- a/data/webapi/entities/order-v2.yaml
+++ b/data/webapi/entities/order-v2.yaml
@@ -109,7 +109,7 @@ example: |
     "filled_avg_price": "106.00",
     "status": "accepted",
     "extended_hours": false,
-    "legs": null
+    "legs": null,
     "trail_price": "1.05",
     "trail_percent": null,
     "hwm": "108.05"


### PR DESCRIPTION
The order yaml in the docs is missing a comma after legs since the new `trail_` fields were added