### PR TITLE
Updates in C# order placement examples

### DIFF
--- a/content/api-documentation/how-to/orders/examples/placeOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/placeOrder.csharp
@@ -18,16 +18,12 @@ namespace CodeExamples
                 .GetAlpacaTradingClient(new SecretKey(API_KEY, API_SECRET));
 
             // Submit a market order to buy 1 share of Apple at market price
-            var order = await client.PostOrderAsync(
-                new NewOrderRequest("AAPL", 1, OrderSide.Buy, OrderType.Market, TimeInForce.Day));
+            var order = await client.PostOrderAsync(MarketOrder.Buy("AAPL", 1));
 
             // Submit a limit order to attempt to sell 1 share of AMD at a
             // particular price ($20.50) when the market opens
             order = await client.PostOrderAsync(
-                new NewOrderRequest("AMD", 1, OrderSide.Sell, OrderType.Limit, TimeInForce.Opg)
-                {
-                    LimitPrice = 20.50M
-                });
+                LimitOrder.Sell("AMD", 1, 20.50M).WithDuration(TimeInForce.Opg));
 
             Console.Read();
         }

--- a/content/api-documentation/how-to/orders/examples/placeTrailingStopOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/placeTrailingStopOrder.csharp
@@ -24,18 +24,12 @@ namespace CodeExamples
             // Submit a trailing stop order to sell 1 share of Apple at a
             // trailing stop of
             order = await client.PostOrderAsync(
-                new NewOrderRequest("AAPL", 1, OrderSide.Sell, OrderType.TrailingStop, TimeInForce.Day)
-                {
-                    TrailOffsetInDollars = 1.00M  // stop price will be hwm - 1.00$
-                });
+                TrailingStopOrder.Sell("AAPL", 1, TrailOffset.InDollars(1.00M))); // stop price will be hwm - 1.00$
 
             /**
             // Alternatively, you could use trail_percent:
             order = await client.PostOrderAsync(
-                new NewOrderRequest("AAPL", 1, OrderSide.Sell, OrderType.TrailingStop, TimeInForce.Day)
-                {
-                    TrailOffsetInPercent = 1.00M  // stop price will be hwm*0.99
-                });
+                TrailingStopOrder.Sell("AAPL", 1, TrailOffset.InPercent(0.99M))); // stop price will be hwm * 0.99
             */
 
             Console.Read();

--- a/content/api-documentation/how-to/orders/examples/shortOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/shortOrder.csharp
@@ -28,8 +28,7 @@ namespace ShortingExample
                 .GetAlpacaDataClient(new SecretKey(API_KEY, API_SECRET));
 
             // Submit a market order to open a short position of one share
-            var order = await tradingClient.PostOrderAsync(
-                new NewOrderRequest(symbol, 1, OrderSide.Sell, OrderType.Market, TimeInForce.Day));
+            var order = await tradingClient.PostOrderAsync(MarketOrder.Sell(symbol, 1));
             Console.WriteLine("Market order submitted.");
 
             // Submit a limit order to attempt to grow our short position
@@ -40,11 +39,7 @@ namespace ShortingExample
             var price = bars[0].Close;
 
             // Submit another order for one share at that price
-            order = await tradingClient.PostOrderAsync(
-                new NewOrderRequest(symbol, 1, OrderSide.Sell, OrderType.Limit, TimeInForce.Day)
-                {
-                    LimitPrice = price
-                });
+            order = await tradingClient.PostOrderAsync(LimitOrder.Sell(symbol, 1, price));
             Console.WriteLine($"Limit order submitted. Limit price = {order.LimitPrice}");
 
             // Wait a few seconds for our orders to fill...

--- a/content/api-documentation/how-to/orders/examples/useClientOrderId.csharp
+++ b/content/api-documentation/how-to/orders/examples/useClientOrderId.csharp
@@ -22,8 +22,7 @@ namespace CodeExamples
             // Submit a market order and assign it a Client Order ID
             await client.PostOrderAsync(
                 MarketOrder.Buy("AAPL", 1)
-                .WithClientOrderId(CLIENT_ORDER_ID)
-            );
+                    .WithClientOrderId(CLIENT_ORDER_ID));
 
             // Get our order using its Client Order ID
             var order = await client.GetOrderAsync(CLIENT_ORDER_ID);


### PR DESCRIPTION
Use only strongly-typed order placement configuration objects in examples for simplicity.