### PR TITLE
Added a note about the different frames used in the trade stream

### DIFF
--- a/content/api-documentation/api-v2/streaming.md
+++ b/content/api-documentation/api-v2/streaming.md
@@ -17,6 +17,8 @@ choose to listen to.
 
 The details of each stream will be described later in this document.
 
+Note: The trade_updates stream coming from wss://paper-api.alpaca.markets/stream uses Binary frames which differs from the Text frames that comes from the wss://data.alpaca.markets/stream stream
+
 In order to listen to streams, the client sends a `listen` message
 to the server as follows.
 ```


### PR DESCRIPTION
For those that are not using and SDK and implementing these sockets on their own, it'd be good to note that they'd have to use different frames for the trade stream vs data stream