### PR TITLE
Add FEE Activity Type

### DIFF
--- a/content/api-documentation/api-v2/account-activities.md
+++ b/content/api-documentation/api-v2/account-activities.md
@@ -59,6 +59,7 @@ Pagination is handled using the `page_token` and `page_size` parameters. `page_t
 * `OPXRC`: Option exercise
 * `PTC`: Pass Thru Charge
 * `PTR`: Pass Thru Rebate
+* `FEE`: REG/TAF fees
 * `REORG`: Reorg CA
 * `SC`: Symbol change
 * `SSO`: Stock spinoff


### PR DESCRIPTION
Adds the `FEE` Activity Type as announced [here](https://alpaca.markets/blog/reg-taf-fees/).