### PR TITLE
C# SDK 5.0.3 compilation errors/warnings fixes

### DIFF
--- a/content/api-documentation/how-to/account/examples/streaming.csharp
+++ b/content/api-documentation/how-to/account/examples/streaming.csharp
@@ -10,23 +10,23 @@ namespace CodeExamples
 
         private static string API_SECRET = "your_secret_key";
 
-        // Print a message to the console when the account's status changes.
+        // Print a message to the console when the trade's status changes.
         public static async Task Main(string[] args)
         {
-            // Prepare the websocket connection and subscribe to account_updates.
+            // Prepare the websocket connection and subscribe to trade_updates.
             var alpacaStreamingClient = Environments.Paper
                 .GetAlpacaStreamingClient(new SecretKey(API_KEY, API_SECRET));
 
             await alpacaStreamingClient.ConnectAndAuthenticateAsync();
-            alpacaStreamingClient.OnAccountUpdate += HandleAccountUpdate;
+            alpacaStreamingClient.OnTradeUpdate += HandleTradeUpdate;
 
             Console.Read();
         }
 
         // Handle incoming account updates.
-        private static void HandleAccountUpdate(IAccountUpdate update)
+        private static void HandleTradeUpdate(ITradeUpdate update)
         {
-            Console.WriteLine("New account status: " + update.Status.ToString());
+            Console.WriteLine("New trade event: " + update.Event.ToString());
         }
     }
 }

--- a/content/api-documentation/how-to/orders/examples/placeBracketOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/placeBracketOrder.csharp
@@ -23,9 +23,8 @@ namespace ShortingExample
             var dataClient = Alpaca.Markets.Environments.Paper
                 .GetAlpacaDataClient(new SecretKey(API_KEY, API_SECRET));
 
-            var barSet = await dataClient.GetBarSetAsync(
-                new BarSetRequest(symbol, TimeFrame.Minute) { Limit = 1 });
-            var price = barSet[symbol].Single().Close;
+            var snapshot = await dataClient.GetSnapshotAsync(symbol);
+            var price = snapshot.MinuteBar.Close;
 
             // We could buy a position and add a stop-loss and a take-profit of 5 %
             await tradingClient.PostOrderAsync(

--- a/content/api-documentation/how-to/orders/examples/shortOrder.csharp
+++ b/content/api-documentation/how-to/orders/examples/shortOrder.csharp
@@ -33,10 +33,8 @@ namespace ShortingExample
 
             // Submit a limit order to attempt to grow our short position
             // First, get an up-to-date price for our security
-            var barSet = await dataClient.GetBarSetAsync(
-                new BarSetRequest(symbol, TimeFrame.Minute) { Limit = 1 });
-            var bars = barSet[symbol].ToList();
-            var price = bars[0].Close;
+            var snapshot = await dataClient.GetSnapshotAsync(symbol);
+            var price = snapshot.MinuteBar.Close;
 
             // Submit another order for one share at that price
             order = await tradingClient.PostOrderAsync(LimitOrder.Sell(symbol, 1, price));


### PR DESCRIPTION
After releasing the official 5.0.3 NuGet package some examples on the Alpaca documentation site become invalid. This PR contains fixes for these compilation errors.