### PR TITLE
add `sell_short` as possible `side`

### DIFF
--- a/data/webapi/entities/account-trade-activity-v2.yaml
+++ b/data/webapi/entities/account-trade-activity-v2.yaml
@@ -21,7 +21,7 @@ spec:
   - name: side
     type: string
     desc: |
-      `buy` or `sell`
+      `buy`, `sell` or `sell_short`
   - name: symbol
     type: string
     desc: The symbol of the security being traded.


### PR DESCRIPTION
The documentation doesn't reflect that `sell_short` statuses can be returned from the trade-activity endpoint - this PR fixes that