### PR TITLE
Merge duplicated integrations page entries for PredictNow.ai.

### DIFF
--- a/content/about-us/_index.md
+++ b/content/about-us/_index.md
@@ -12,7 +12,7 @@ Alpaca is a technology company headquartered in California Silicon Valley that b
 Alpaca's globally distributed team consists of developers, traders, and brokerage business specialists, who collectively have decades of
 financial services and technology industry experience at organizations such as FINRA, Apple, Wealthfront, Robinhood, EMC, Cloudera, JP Morgan, and Lehman Brothers. Alpaca is co-founded and led by [Yoshi Yokokawa](https://www.linkedin.com/in/yoshiyokokawa/) (CEO) and [Hitoshi Harada](https://www.linkedin.com/in/hitoshi-harada-02b01425/) (CTO/CPO). Our investors include a group of well-capitalized
 investors including Portage Ventures, Spark Capital, Tribe Capital, Social Leverage, Horizons Ventures, Elderidge, and Y Combinator as well as highly experienced industry angel investors
-such as Joshua S. Levine (former CTO/COO of ETRADE), Nate Rodland (former COO of Robinhood & GP of Elefund), Patrick O’Shaughnessy (“Invest Like the Best” podcast host, CEO of O’Shaughnessy Asset Management, & Partner of Positive Sum), Jacqueline Reses (former Executive Chairman of Square Financial Services), Asiff Hirjii (former President/COO of Coinbase), Aaron Levie (CEO of Box), and founders of leading Fintech companies including Plaid and Wealthsimple.
+such as Joshua S. Levine (former CTO/COO of ETRADE), Nate Rodland (former COO of Robinhood & GP of Elefund), Patrick O’Shaughnessy (“Invest Like the Best” podcast host & Partner of Positive Sum), Jacqueline Reses (former Executive Chairman of Square Financial Services), Asiff Hirjii (former President/COO of Coinbase), Aaron Levie (CEO of Box), and founders of leading Fintech companies including Plaid and Wealthsimple.
 
 ## Who Is Alpaca For?
 

--- a/content/alpaca-works-with/_index.md
+++ b/content/alpaca-works-with/_index.md
@@ -20,12 +20,11 @@ Alpaca works with many ways to trade! We pride ourselves in enabling many partne
 * IFTTT ([How it works](./ifttt), [Partner page](https://ifttt.com/alpaca)): Use triggers to build “if this, then that” services that launch trades or respond to them. IFTTT is trusted by over 18 million consumers and 130 thousand developers accross the world.
 * Zapier ([Partner page](https://zapier.com/apps/alpaca/integrations)): Connect to thousands of apps to automate your trading flow. Join the community of more than 3 million people that rely on Zapier.
 * Slack ([How it works](https://alpaca.markets/docs/alpaca-works-with/alpaca-for-slack/)): Quickly manage your Alpaca brokerage account right inside Slack. With simple commands, you can have AlpacaBot get your orders and positions, and you can even tell it to place orders for you.
-* PredictNow.ai ([How it works](./predictnow)): A no-code machine learning SaaS helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade.
+* PredictNow.ai ([How it works](./predictnow), [Partner page](https://www.predictnow.ai/)): A no-code machine learning SaaS helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade.
 * MetaTrader 5 ([Partner page](https://www.metatrader5.com/en/terminal/help/startworking/acc_open)): Convenient and Functional Trading Platform featuring technical analysis, fundamental analysis, automated trading, and trading from mobile devices.
 * Algo Bulls ([Partner page](https://help.algobulls.com/broker/alpaca/)): Make use of powerful features like Live Trading, Paper Trading, Backtesting, Strategy Customizations, Python Build, and much more directly from the website or Android App.
 * Trellis ([How it works](https://www.trytrellis.co/)): Build a trading bot without code, connect with social integrations, and compete against other users in both paper and live trading all free of charge.
-* PredictNow.ai ([How it works](https://www.predictnow.ai/)): A no-code machine learning SaaS, helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade.
-            
+
 
 
 ## Open Source Integration Libraries

--- a/content/api-documentation/api-v2/market-data/alpaca-data-api-v1/_index.md
+++ b/content/api-documentation/api-v2/market-data/alpaca-data-api-v1/_index.md
@@ -7,7 +7,7 @@ summary: Alpaca Data API v1 provides the market data available to the client use
 # Market Data
 
 
-**The Data API v1 will be deprecated on August 26th, 2021, so please make sure to update any existing systems to use the new endpoint before that date.**
+**The Data API v1 will be deprecated on September 26th, 2021, so please make sure to update any existing systems to use the new endpoint before that date.**
 
 ## Overview
 

--- a/content/api-documentation/api-v2/market-data/alpaca-data-api-v2/historical/_index.md
+++ b/content/api-documentation/api-v2/market-data/alpaca-data-api-v2/historical/_index.md
@@ -4,6 +4,8 @@ weight: 100
 summary: Alpaca Data API v2 provides three types of historical data. Trades, quotes and bars. To check the multiple endpoints click on the card.
 ---
 
+**Adjusted bars are now in indefinite beta! With split-adjusted historical price data, we remove large gaps caused by splits. This offers a more accurate representation of stock growth from the past until the present.Please note that this addition does not change current behavior, every call will default to raw adjustment.**
+
 # Historical Data
 
 Alpaca Data API v2 provides three types of historical data: [trades]({{<

--- a/content/trading-on-alpaca/orders.md
+++ b/content/trading-on-alpaca/orders.md
@@ -141,7 +141,7 @@ the features of a stop order with those of a limit order and is used to mitigate
 The stop-limit order will be executed at a specified limit price, or better, after
 a given stop price has been reached. Once the stop price is reached, the
 stop-limit order becomes a limit order to buy or sell at the limit price
-or better.
+or better. In the case of a gap down in the market that causes the election of your order, but not the execution, you order will remain active as a limit order until it is executable or cancelled.
 
 In order to submit a stop limit order, you will need to specify both the
 limit and stop price parameters in the API.

--- a/data/webapi/endpoints/bars-v2.yaml
+++ b/data/webapi/endpoints/bars-v2.yaml
@@ -30,7 +30,6 @@ endpoints:
             desc: |
               Timeframe for the aggregation. Values are customizeable, frequently used examples: `1Min`, `15Min`, `1Hour`, `1Day`.
           - name: adjustment
-            required: true
             type: string
             desc: |
               Specifies the corporate action adjustment for the stocks. Enum: 'raw', 'split', 'dividend' or 'all'. Default value is 'raw'.

--- a/data/webapi/endpoints/bars-v2.yaml
+++ b/data/webapi/endpoints/bars-v2.yaml
@@ -28,7 +28,12 @@ endpoints:
             required: true
             type: string
             desc: |
-              Timeframe for the aggregation. Available values are: `1Min`, `1Hour`, `1Day`.
+              Timeframe for the aggregation. Values are customizeable, frequently used examples: `1Min`, `15Min`, `1Hour`, `1Day`.
+          - name: adjustment
+            required: true
+            type: string
+            desc: |
+              Specifies the corporate action adjustment for the stocks. Enum: 'raw', 'split', 'dividend' or 'all'. Default value is 'raw'.
       returns: |
         A bars response object.
       errors:


### PR DESCRIPTION
Looks like this entry for PredictNow.ai was duplicated due to a merge conflict. Removed the duplicated and added a link to partner page in the original entry. 