### PR TITLE
Merge duplicated integrations page entries for PredictNow.ai.

### DIFF
--- a/content/alpaca-works-with/_index.md
+++ b/content/alpaca-works-with/_index.md
@@ -20,12 +20,11 @@ Alpaca works with many ways to trade! We pride ourselves in enabling many partne
 * IFTTT ([How it works](./ifttt), [Partner page](https://ifttt.com/alpaca)): Use triggers to build “if this, then that” services that launch trades or respond to them. IFTTT is trusted by over 18 million consumers and 130 thousand developers accross the world.
 * Zapier ([Partner page](https://zapier.com/apps/alpaca/integrations)): Connect to thousands of apps to automate your trading flow. Join the community of more than 3 million people that rely on Zapier.
 * Slack ([How it works](https://alpaca.markets/docs/alpaca-works-with/alpaca-for-slack/)): Quickly manage your Alpaca brokerage account right inside Slack. With simple commands, you can have AlpacaBot get your orders and positions, and you can even tell it to place orders for you.
-* PredictNow.ai ([How it works](./predictnow)): A no-code machine learning SaaS helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade.
+* PredictNow.ai ([How it works](./predictnow), [Partner page](https://www.predictnow.ai/)): A no-code machine learning SaaS helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade.
 * MetaTrader 5 ([Partner page](https://www.metatrader5.com/en/terminal/help/startworking/acc_open)): Convenient and Functional Trading Platform featuring technical analysis, fundamental analysis, automated trading, and trading from mobile devices.
 * Algo Bulls ([Partner page](https://help.algobulls.com/broker/alpaca/)): Make use of powerful features like Live Trading, Paper Trading, Backtesting, Strategy Customizations, Python Build, and much more directly from the website or Android App.
 * Trellis ([How it works](https://www.trytrellis.co/)): Build a trading bot without code, connect with social integrations, and compete against other users in both paper and live trading all free of charge.
-* PredictNow.ai ([How it works](https://www.predictnow.ai/)): A no-code machine learning SaaS, helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade.
-            
+
 
 
 ## Open Source Integration Libraries


### PR DESCRIPTION
Looks like this entry for PredictNow.ai was duplicated due to a merge conflict.

Removed the duplicated and added a "Partner page" link in the original entry.